### PR TITLE
Replace StaticResource with ThemeResource so that colors and brushes update when switching light/dark mode

### DIFF
--- a/CustomThemesPackage/Acrylic.xaml
+++ b/CustomThemesPackage/Acrylic.xaml
@@ -143,7 +143,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Black Pixel.xaml
+++ b/CustomThemesPackage/Black Pixel.xaml
@@ -1,21 +1,48 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#1A73E8" AltHigh="#000000" AltLow="#000000" AltMedium="#000000" AltMediumHigh="#000000" AltMediumLow="#000000" BaseHigh="#FFFFFF" BaseLow="#212121" BaseMedium="#FFFFFF" BaseMediumHigh="#FFFFFF" BaseMediumLow="#99FFFFFF" ChromeAltLow="#212121" ChromeBlackHigh="#000000" ChromeBlackLow="#000000" ChromeBlackMedium="#000000" ChromeBlackMediumLow="#000000" ChromeDisabledHigh="#212121" ChromeDisabledLow="#1A73E8" ChromeGray="#212121" ChromeHigh="#1A73E8" ChromeLow="#212121" ChromeMedium="#212121" ChromeMediumLow="#181818" ChromeWhite="#FFFFFF" ListLow="#212121" ListMedium="#1A73E8" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#1A73E8"
+                    AltHigh="#000000"
+                    AltLow="#000000"
+                    AltMedium="#000000"
+                    AltMediumHigh="#000000"
+                    AltMediumLow="#000000"
+                    BaseHigh="#FFFFFF"
+                    BaseLow="#212121"
+                    BaseMedium="#FFFFFF"
+                    BaseMediumHigh="#FFFFFF"
+                    BaseMediumLow="#99FFFFFF"
+                    ChromeAltLow="#212121"
+                    ChromeBlackHigh="#000000"
+                    ChromeBlackLow="#000000"
+                    ChromeBlackMedium="#000000"
+                    ChromeBlackMediumLow="#000000"
+                    ChromeDisabledHigh="#212121"
+                    ChromeDisabledLow="#1A73E8"
+                    ChromeGray="#212121"
+                    ChromeHigh="#1A73E8"
+                    ChromeLow="#212121"
+                    ChromeMedium="#212121"
+                    ChromeMediumLow="#181818"
+                    ChromeWhite="#FFFFFF"
+                    ListLow="#212121"
+                    ListMedium="#1A73E8" />
                 <ResourceDictionary>
                     <Color x:Key="SolidBackgroundAcrylic">#181818</Color>
                     <Color x:Key="SolidBackgroundFillColorBase">#000000</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#000000</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#181818</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#181818</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                     <Color x:Key="ControlStrokeColorDefault">#000000</Color>
                     <Color x:Key="ControlStrokeColorSecondary">#000000</Color>
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#181818" />

--- a/CustomThemesPackage/Bound to be Blue.xaml
+++ b/CustomThemesPackage/Bound to be Blue.xaml
@@ -1,11 +1,38 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCC4D11" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF2F7BAD" BaseMedium="#FF8DBFDF" BaseMediumHigh="#FFA5D0EC" BaseMediumLow="#FF5E9DC6" ChromeAltLow="#FFA5D0EC" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFA5D0EC" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF2F7BAD" ChromeDisabledLow="#FF8DBFDF" ChromeGray="#FF76AED3" ChromeHigh="#FF76AED3" ChromeLow="#FF093B73" ChromeMedium="#FF134B82" ChromeMediumLow="#FF266B9F" ChromeWhite="#FFFFFFFF" ListLow="#FF134B82" ListMedium="#FF2F7BAD" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCC4D11"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF2F7BAD"
+                    BaseMedium="#FF8DBFDF"
+                    BaseMediumHigh="#FFA5D0EC"
+                    BaseMediumLow="#FF5E9DC6"
+                    ChromeAltLow="#FFA5D0EC"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFA5D0EC"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF2F7BAD"
+                    ChromeDisabledLow="#FF8DBFDF"
+                    ChromeGray="#FF76AED3"
+                    ChromeHigh="#FF76AED3"
+                    ChromeLow="#FF093B73"
+                    ChromeMedium="#FF134B82"
+                    ChromeMediumLow="#FF266B9F"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF134B82"
+                    ListMedium="#FF2F7BAD" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCC4D11</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -37,11 +64,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF2F7BAD</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF134B82</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF2F7BAD</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">3,3,3,3</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">5,5,5,5</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
@@ -66,7 +98,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">2,2,2,2</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">2</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FFD4632D</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFDC7949</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFE58E66</Color>
@@ -74,13 +106,39 @@
                     <Color x:Key="SystemAccentColorLight2">#FFA62F0A</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF932107</Color>
                     <Color x:Key="RegionColor">#FF0D2644</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCF842B" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FF7CBEE0" BaseMedium="#FF3282A8" BaseMediumHigh="#FF005A83" BaseMediumLow="#FF196E96" ChromeAltLow="#FF005A83" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF7CBEE0" ChromeBlackMedium="#FF005A83" ChromeBlackMediumLow="#FF3282A8" ChromeDisabledHigh="#FF7CBEE0" ChromeDisabledLow="#FF3282A8" ChromeGray="#FF196E96" ChromeHigh="#FF7CBEE0" ChromeLow="#FFC1E9FE" ChromeMedium="#FFB3E0F8" ChromeMediumLow="#FFC1E9FE" ChromeWhite="#FFFFFFFF" ListLow="#FFB3E0F8" ListMedium="#FF7CBEE0" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCF842B"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FF7CBEE0"
+                    BaseMedium="#FF3282A8"
+                    BaseMediumHigh="#FF005A83"
+                    BaseMediumLow="#FF196E96"
+                    ChromeAltLow="#FF005A83"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF7CBEE0"
+                    ChromeBlackMedium="#FF005A83"
+                    ChromeBlackMediumLow="#FF3282A8"
+                    ChromeDisabledHigh="#FF7CBEE0"
+                    ChromeDisabledLow="#FF3282A8"
+                    ChromeGray="#FF196E96"
+                    ChromeHigh="#FF7CBEE0"
+                    ChromeLow="#FFC1E9FE"
+                    ChromeMedium="#FFB3E0F8"
+                    ChromeMediumLow="#FFC1E9FE"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFB3E0F8"
+                    ListMedium="#FF7CBEE0" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCF842B</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -112,11 +170,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF7CBEE0</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFB3E0F8</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF7CBEE0</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">3,3,3,3</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">5,5,5,5</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">2</Thickness>
@@ -141,22 +204,26 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">2,2,2,2</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">2,2,2,2</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">2</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FFD69344</Color>
                     <Color x:Key="SystemAccentColorLight2">#FFDDA25C</Color>
                     <Color x:Key="SystemAccentColorLight3">#FFE5B275</Color>
                     <Color x:Key="SystemAccentColorDark1">#FFBB7122</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFA75E1A</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF924C11</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFBDE5FF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Deep Sea.xaml
+++ b/CustomThemesPackage/Deep Sea.xaml
@@ -1,22 +1,54 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                 <Windows10version1809:ColorPaletteResources Accent="#FF0073CF" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF0D3578" BaseMedium="#FF809BC5" BaseMediumHigh="#FF9DB5D8" BaseMediumLow="#FF47689E" ChromeAltLow="#FF9DB5D8" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF9DB5D8" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF0D3578" ChromeDisabledLow="#FF809BC5" ChromeGray="#FF6382B2" ChromeHigh="#FF6382B2" ChromeLow="#FF03174E" ChromeMedium="#FF051F58" ChromeMediumLow="#FF0A2E6D" ChromeWhite="#FFFFFFFF" ListLow="#FF051F58" ListMedium="#FF0D3578" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF0073CF"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF0D3578"
+                    BaseMedium="#FF809BC5"
+                    BaseMediumHigh="#FF9DB5D8"
+                    BaseMediumLow="#FF47689E"
+                    ChromeAltLow="#FF9DB5D8"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF9DB5D8"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF0D3578"
+                    ChromeDisabledLow="#FF809BC5"
+                    ChromeGray="#FF6382B2"
+                    ChromeHigh="#FF6382B2"
+                    ChromeLow="#FF03174E"
+                    ChromeMedium="#FF051F58"
+                    ChromeMediumLow="#FF0A2E6D"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF051F58"
+                    ListMedium="#FF0D3578" />
                 <ResourceDictionary>
                     <Color x:Key="SystemChromeAltMediumHighColor">#CC002236</Color>
                     <Color x:Key="SystemChromeAltHighColor">#FF040378</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF020157</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF040378</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -41,7 +73,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FF1D85D7</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF3B97DF</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF58A8E8</Color>
@@ -49,14 +81,14 @@
                     <Color x:Key="SystemAccentColorLight2">#FF0055AD</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF00459D</Color>
                     <Color x:Key="RegionColor">#FF002236</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
-                    
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
+
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
-                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource RegionColor}" />
                     <SolidColorBrush x:Key="SystemControlPageBackgroundMediumAltMediumBrush" Color="#99000000" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource RegionColor}" />
 
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#040378" />
                     <SolidColorBrush x:Key="ControlFillColorSecondaryBrush" Color="#00277B" />
@@ -64,8 +96,8 @@
                     <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="#020262" />
                     <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="#0055AD" />
                     <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="#000041" />
-                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource ControlStrokeColorDefault}" />
-                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource ControlStrokeColorSecondary}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{ThemeResource ControlStrokeColorSecondary}" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="#93CCF8" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="#76BAF0" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="#58A8E8" />
@@ -75,7 +107,33 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF0073CF" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FFCCCCCC" BaseMedium="#FF898989" BaseMediumHigh="#FF5D5D5D" BaseMediumLow="#FF737373" ChromeAltLow="#FF5D5D5D" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFCCCCCC" ChromeBlackMedium="#FF5D5D5D" ChromeBlackMediumLow="#FF898989" ChromeDisabledHigh="#FFCCCCCC" ChromeDisabledLow="#FF898989" ChromeGray="#FF737373" ChromeHigh="#FFCCCCCC" ChromeLow="#FFECECEC" ChromeMedium="#FFE6E6E6" ChromeMediumLow="#FFECECEC" ChromeWhite="#FFFFFFFF" ListLow="#FFE6E6E6" ListMedium="#FFCCCCCC" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF0073CF"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FFCCCCCC"
+                    BaseMedium="#FF898989"
+                    BaseMediumHigh="#FF5D5D5D"
+                    BaseMediumLow="#FF737373"
+                    ChromeAltLow="#FF5D5D5D"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFCCCCCC"
+                    ChromeBlackMedium="#FF5D5D5D"
+                    ChromeBlackMediumLow="#FF898989"
+                    ChromeDisabledHigh="#FFCCCCCC"
+                    ChromeDisabledLow="#FF898989"
+                    ChromeGray="#FF737373"
+                    ChromeHigh="#FFCCCCCC"
+                    ChromeLow="#FFECECEC"
+                    ChromeMedium="#FFE6E6E6"
+                    ChromeMediumLow="#FFECECEC"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFE6E6E6"
+                    ListMedium="#FFCCCCCC" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF0073CF</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -107,11 +165,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FFCCCCCC</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFE6E6E6</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FFCCCCCC</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -136,22 +199,26 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF1D85D7</Color>
                     <Color x:Key="SystemAccentColorLight2">#FF3B97DF</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF58A8E8</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF0064BE</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF0055AD</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF00459D</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFFFFFFF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Discord Purple.xaml
+++ b/CustomThemesPackage/Discord Purple.xaml
@@ -1,12 +1,39 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF7289DA" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF23272A" BaseMedium="#FF8B959E" BaseMediumHigh="#FFA5B0BB" BaseMediumLow="#FF575E64" ChromeAltLow="#FFA5B0BB" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFA5B0BB" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF23272A" ChromeDisabledLow="#FF8B959E" ChromeGray="#FF717981" ChromeHigh="#FF717981" ChromeLow="#FF071325" ChromeMedium="#FF0E1826" ChromeMediumLow="#FF1C2229" ChromeWhite="#FFFFFFFF" ListLow="#FF0E1826" ListMedium="#FF23272A" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF7289DA"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF23272A"
+                    BaseMedium="#FF8B959E"
+                    BaseMediumHigh="#FFA5B0BB"
+                    BaseMediumLow="#FF575E64"
+                    ChromeAltLow="#FFA5B0BB"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFA5B0BB"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF23272A"
+                    ChromeDisabledLow="#FF8B959E"
+                    ChromeGray="#FF717981"
+                    ChromeHigh="#FF717981"
+                    ChromeLow="#FF071325"
+                    ChromeMedium="#FF0E1826"
+                    ChromeMediumLow="#FF1C2229"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF0E1826"
+                    ListMedium="#FF23272A" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF7289DA</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,11 +65,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF23272A</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF0E1826</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF23272A</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -67,7 +99,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FF8398E1</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF94A7E8</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFA5B5EF</Color>
@@ -75,13 +107,39 @@
                     <Color x:Key="SystemAccentColorLight2">#FF4465B6</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF2E54A5</Color>
                     <Color x:Key="RegionColor">#FF2C2F33</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF7289DA" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FF99AAB5" BaseMedium="#FF457189" BaseMediumHigh="#FF0D4B6B" BaseMediumLow="#FF295E7A" ChromeAltLow="#FF0D4B6B" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF99AAB5" ChromeBlackMedium="#FF0D4B6B" ChromeBlackMediumLow="#FF457189" ChromeDisabledHigh="#FF99AAB5" ChromeDisabledLow="#FF457189" ChromeGray="#FF295E7A" ChromeHigh="#FF99AAB5" ChromeLow="#FFCDE2EE" ChromeMedium="#FFC3D7E3" ChromeMediumLow="#FFCDE2EE" ChromeWhite="#FFFFFFFF" ListLow="#FFC3D7E3" ListMedium="#FF99AAB5" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF7289DA"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FF99AAB5"
+                    BaseMedium="#FF457189"
+                    BaseMediumHigh="#FF0D4B6B"
+                    BaseMediumLow="#FF295E7A"
+                    ChromeAltLow="#FF0D4B6B"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF99AAB5"
+                    ChromeBlackMedium="#FF0D4B6B"
+                    ChromeBlackMediumLow="#FF457189"
+                    ChromeDisabledHigh="#FF99AAB5"
+                    ChromeDisabledLow="#FF457189"
+                    ChromeGray="#FF295E7A"
+                    ChromeHigh="#FF99AAB5"
+                    ChromeLow="#FFCDE2EE"
+                    ChromeMedium="#FFC3D7E3"
+                    ChromeMediumLow="#FFCDE2EE"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFC3D7E3"
+                    ListMedium="#FF99AAB5" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF7289DA</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -113,11 +171,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF99AAB5</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFC3D7E3</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF99AAB5</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -142,22 +205,26 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF8398E1</Color>
                     <Color x:Key="SystemAccentColorLight2">#FF94A7E8</Color>
                     <Color x:Key="SystemAccentColorLight3">#FFA5B5EF</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF5B77C8</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF4465B6</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF2E54A5</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFFFFFFF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Dracula.xaml
+++ b/CustomThemesPackage/Dracula.xaml
@@ -1,12 +1,39 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFBD93F9" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF44475A" BaseMedium="#FFA0A4B6" BaseMediumHigh="#FFB7BBCD" BaseMediumLow="#FF727588" ChromeAltLow="#FFB7BBCD" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFB7BBCD" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF44475A" ChromeDisabledLow="#FFA0A4B6" ChromeGray="#FF898D9F" ChromeHigh="#FF898D9F" ChromeLow="#FF0E1E3D" ChromeMedium="#FF1B2844" ChromeMediumLow="#FF363D53" ChromeWhite="#FFFFFFFF" ListLow="#FF1B2844" ListMedium="#FF44475A" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFBD93F9"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF44475A"
+                    BaseMedium="#FFA0A4B6"
+                    BaseMediumHigh="#FFB7BBCD"
+                    BaseMediumLow="#FF727588"
+                    ChromeAltLow="#FFB7BBCD"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFB7BBCD"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF44475A"
+                    ChromeDisabledLow="#FFA0A4B6"
+                    ChromeGray="#FF898D9F"
+                    ChromeHigh="#FF898D9F"
+                    ChromeLow="#FF0E1E3D"
+                    ChromeMedium="#FF1B2844"
+                    ChromeMediumLow="#FF363D53"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF1B2844"
+                    ListMedium="#FF44475A" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFBD93F9</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,11 +65,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF44475A</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF1B2844</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF44475A</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -67,7 +99,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FFC6A0FA</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFCFADFB</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFD8BBFD</Color>
@@ -75,23 +107,23 @@
                     <Color x:Key="SystemAccentColorLight2">#FF936BCE</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF7F58B9</Color>
                     <Color x:Key="RegionColor">#FF282A36</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
-                    <!-- Override with custom colors -->
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
+                    <!--  Override with custom colors  -->
                     <Color x:Key="SolidBackgroundFillColorBase">#282A36</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#282A36</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#44475A</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#44475A</Color>
                     <Color x:Key="SolidBackgroundAcrylic">#44475A</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Lavender.xaml
+++ b/CustomThemesPackage/Lavender.xaml
@@ -1,12 +1,39 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF8961CC" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF64576B" BaseMedium="#FFB6AABC" BaseMediumHigh="#FFCBBFD0" BaseMediumLow="#FF8D8193" ChromeAltLow="#FFCBBFD0" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFCBBFD0" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF64576B" ChromeDisabledLow="#FFB6AABC" ChromeGray="#FFA295A8" ChromeHigh="#FFA295A8" ChromeLow="#FF332041" ChromeMedium="#FF3F2E4B" ChromeMediumLow="#FF584960" ChromeWhite="#FFFFFFFF" ListLow="#FF3F2E4B" ListMedium="#FF64576B" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF8961CC"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF64576B"
+                    BaseMedium="#FFB6AABC"
+                    BaseMediumHigh="#FFCBBFD0"
+                    BaseMediumLow="#FF8D8193"
+                    ChromeAltLow="#FFCBBFD0"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFCBBFD0"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF64576B"
+                    ChromeDisabledLow="#FFB6AABC"
+                    ChromeGray="#FFA295A8"
+                    ChromeHigh="#FFA295A8"
+                    ChromeLow="#FF332041"
+                    ChromeMedium="#FF3F2E4B"
+                    ChromeMediumLow="#FF584960"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF3F2E4B"
+                    ListMedium="#FF64576B" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF8961CC</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,8 +65,13 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF64576B</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF3F2E4B</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF64576B</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system generated accent colors -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FF9875D4</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFA788DD</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFB79CE5</Color>
@@ -47,7 +79,7 @@
                     <Color x:Key="SystemAccentColorLight2">#FF6543A9</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF543397</Color>
                     <Color x:Key="RegionColor">#FF262738</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                     <Color x:Key="BaseColor">#FF64576B</Color>
                     <Color x:Key="BasePalette000Color">#FFCBBFD0</Color>
                     <Color x:Key="BasePalette100Color">#FFB6AABC</Color>
@@ -72,45 +104,71 @@
                     <Color x:Key="PrimaryPalette800Color">#FF543397</Color>
                     <Color x:Key="PrimaryPalette900Color">#FF422486</Color>
                     <Color x:Key="PrimaryPalette1000Color">#FF301574</Color>
-                    <SolidColorBrush x:Key="BaseBrush" Color="{StaticResource BaseColor}" />
-                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{StaticResource BasePalette300Color}" />
-                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{StaticResource BasePalette400Color}" />
-                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{StaticResource BasePalette500Color}" />
-                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{StaticResource BasePalette600Color}" />
-                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{StaticResource BasePalette700Color}" />
-                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{StaticResource BasePalette800Color}" />
-                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{StaticResource BasePalette900Color}" />
-                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{StaticResource BasePalette1000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{StaticResource PrimaryPalette000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{StaticResource PrimaryPalette100Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{StaticResource PrimaryPalette200Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{StaticResource PrimaryPalette300Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{StaticResource PrimaryPalette400Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{StaticResource PrimaryPalette500Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{StaticResource PrimaryPalette600Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{StaticResource PrimaryPalette700Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{StaticResource PrimaryPalette800Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{StaticResource PrimaryPalette900Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{StaticResource PrimaryPalette1000Color}" />
-                    <!-- Files-specific overrides -->
+                    <SolidColorBrush x:Key="BaseBrush" Color="{ThemeResource BaseColor}" />
+                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{ThemeResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{ThemeResource BasePalette400Color}" />
+                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{ThemeResource BasePalette500Color}" />
+                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{ThemeResource BasePalette600Color}" />
+                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{ThemeResource BasePalette700Color}" />
+                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{ThemeResource BasePalette800Color}" />
+                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{ThemeResource BasePalette900Color}" />
+                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{ThemeResource BasePalette1000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{ThemeResource PrimaryPalette000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{ThemeResource PrimaryPalette100Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{ThemeResource PrimaryPalette200Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{ThemeResource PrimaryPalette300Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{ThemeResource PrimaryPalette400Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{ThemeResource PrimaryPalette500Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{ThemeResource PrimaryPalette600Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{ThemeResource PrimaryPalette700Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{ThemeResource PrimaryPalette800Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{ThemeResource PrimaryPalette900Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{ThemeResource PrimaryPalette1000Color}" />
+                    <!--  Files-specific overrides  -->
                     <Color x:Key="SolidBackgroundFillColorBase">#FF262738</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#FF3F2E4B</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#FF332041</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FF271236</Color>
-                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource RegionColor}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource RegionColor}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource BasePalette300Color}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF8961CC" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FFEECEFF" BaseMedium="#FFA987BC" BaseMediumHigh="#FF7B5890" BaseMediumLow="#FF9270A6" ChromeAltLow="#FF7B5890" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFEECEFF" ChromeBlackMedium="#FF7B5890" ChromeBlackMediumLow="#FFA987BC" ChromeDisabledHigh="#FFEECEFF" ChromeDisabledLow="#FFA987BC" ChromeGray="#FF9270A6" ChromeHigh="#FFEECEFF" ChromeLow="#FFFEEAFF" ChromeMedium="#FFFBE4FF" ChromeMediumLow="#FFFEEAFF" ChromeWhite="#FFFFFFFF" ListLow="#FFFBE4FF" ListMedium="#FFEECEFF" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF8961CC"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FFEECEFF"
+                    BaseMedium="#FFA987BC"
+                    BaseMediumHigh="#FF7B5890"
+                    BaseMediumLow="#FF9270A6"
+                    ChromeAltLow="#FF7B5890"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFEECEFF"
+                    ChromeBlackMedium="#FF7B5890"
+                    ChromeBlackMediumLow="#FFA987BC"
+                    ChromeDisabledHigh="#FFEECEFF"
+                    ChromeDisabledLow="#FFA987BC"
+                    ChromeGray="#FF9270A6"
+                    ChromeHigh="#FFEECEFF"
+                    ChromeLow="#FFFEEAFF"
+                    ChromeMedium="#FFFBE4FF"
+                    ChromeMediumLow="#FFFEEAFF"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFFBE4FF"
+                    ListMedium="#FFEECEFF" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF8961CC</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -142,17 +200,26 @@
                     <Color x:Key="SystemChromeAltHighColor">#FFEECEFF</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFFBE4FF</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FFEECEFF</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system generated accent colors -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF9875D4</Color>
                     <Color x:Key="SystemAccentColorLight2">#FFA788DD</Color>
                     <Color x:Key="SystemAccentColorLight3">#FFB79CE5</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF7752BA</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF6543A9</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF543397</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFFEF6FF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                     <Color x:Key="BaseColor">#FFEECEFF</Color>
                     <Color x:Key="BasePalette000Color">#FFFEEAFF</Color>
                     <Color x:Key="BasePalette100Color">#FFFBE4FF</Color>
@@ -177,45 +244,45 @@
                     <Color x:Key="PrimaryPalette800Color">#FF543397</Color>
                     <Color x:Key="PrimaryPalette900Color">#FF422486</Color>
                     <Color x:Key="PrimaryPalette1000Color">#FF301574</Color>
-                    <SolidColorBrush x:Key="BaseBrush" Color="{StaticResource BaseColor}" />
-                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{StaticResource BasePalette300Color}" />
-                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{StaticResource BasePalette400Color}" />
-                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{StaticResource BasePalette500Color}" />
-                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{StaticResource BasePalette600Color}" />
-                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{StaticResource BasePalette700Color}" />
-                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{StaticResource BasePalette800Color}" />
-                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{StaticResource BasePalette900Color}" />
-                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{StaticResource BasePalette1000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{StaticResource PrimaryPalette000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{StaticResource PrimaryPalette100Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{StaticResource PrimaryPalette200Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{StaticResource PrimaryPalette300Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{StaticResource PrimaryPalette400Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{StaticResource PrimaryPalette500Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{StaticResource PrimaryPalette600Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{StaticResource PrimaryPalette700Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{StaticResource PrimaryPalette800Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{StaticResource PrimaryPalette900Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{StaticResource PrimaryPalette1000Color}" />
-                    <!-- Files-specific overrides -->
+                    <SolidColorBrush x:Key="BaseBrush" Color="{ThemeResource BaseColor}" />
+                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{ThemeResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{ThemeResource BasePalette400Color}" />
+                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{ThemeResource BasePalette500Color}" />
+                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{ThemeResource BasePalette600Color}" />
+                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{ThemeResource BasePalette700Color}" />
+                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{ThemeResource BasePalette800Color}" />
+                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{ThemeResource BasePalette900Color}" />
+                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{ThemeResource BasePalette1000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{ThemeResource PrimaryPalette000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{ThemeResource PrimaryPalette100Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{ThemeResource PrimaryPalette200Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{ThemeResource PrimaryPalette300Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{ThemeResource PrimaryPalette400Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{ThemeResource PrimaryPalette500Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{ThemeResource PrimaryPalette600Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{ThemeResource PrimaryPalette700Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{ThemeResource PrimaryPalette800Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{ThemeResource PrimaryPalette900Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{ThemeResource PrimaryPalette1000Color}" />
+                    <!--  Files-specific overrides  -->
                     <Color x:Key="SolidBackgroundFillColorBase">#FFFEF6FF</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#FFFBE4FF</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#FFF8DFFF</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FFF4D9FF</Color>
-                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource BasePalette300Color}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Luxury red.xaml
+++ b/CustomThemesPackage/Luxury red.xaml
@@ -1,12 +1,39 @@
-<!-- MIT License -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  MIT License  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCF0000" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF333333" BaseMedium="#FF9A9A9A" BaseMediumHigh="#FFB4B4B4" BaseMediumLow="#FF676767" ChromeAltLow="#FFB4B4B4" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFB4B4B4" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF333333" ChromeDisabledLow="#FF9A9A9A" ChromeGray="#FF808080" ChromeHigh="#FF808080" ChromeLow="#FF151515" ChromeMedium="#FF1D1D1D" ChromeMediumLow="#FF2C2C2C" ChromeWhite="#FFFFFFFF" ListLow="#FF1D1D1D" ListMedium="#FF333333" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCF0000"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF333333"
+                    BaseMedium="#FF9A9A9A"
+                    BaseMediumHigh="#FFB4B4B4"
+                    BaseMediumLow="#FF676767"
+                    ChromeAltLow="#FFB4B4B4"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFB4B4B4"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF333333"
+                    ChromeDisabledLow="#FF9A9A9A"
+                    ChromeGray="#FF808080"
+                    ChromeHigh="#FF808080"
+                    ChromeLow="#FF151515"
+                    ChromeMedium="#FF1D1D1D"
+                    ChromeMediumLow="#FF2C2C2C"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF1D1D1D"
+                    ListMedium="#FF333333" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCF0000</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,12 +65,17 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF333333</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF1D1D1D</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF333333</Color>
-                     <Color x:Key="SolidBackgroundAcrylic">#9CAACC</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <Color x:Key="SolidBackgroundAcrylic">#9CAACC</Color>
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">5,5,5,5</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">0</Thickness>
@@ -68,7 +100,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">0,0,0,0</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">0</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FFD71F1F</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFDF3E3F</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFE75E5E</Color>
@@ -76,13 +108,39 @@
                     <Color x:Key="SystemAccentColorLight2">#FFA90000</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF960000</Color>
                     <Color x:Key="RegionColor">#FF000000</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF0954CF" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FF9CAACC" BaseMedium="#FF526F9B" BaseMediumHigh="#FF20477A" BaseMediumLow="#FF395B8A" ChromeAltLow="#FF20477A" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF9CAACC" ChromeBlackMedium="#FF20477A" ChromeBlackMediumLow="#FF526F9B" ChromeDisabledHigh="#FF9CAACC" ChromeDisabledLow="#FF526F9B" ChromeGray="#FF395B8A" ChromeHigh="#FF9CAACC" ChromeLow="#FFD4E0F8" ChromeMedium="#FFC9D5EF" ChromeMediumLow="#FFD4E0F8" ChromeWhite="#FFFFFFFF" ListLow="#FFC9D5EF" ListMedium="#FF9CAACC" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF0954CF"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FF9CAACC"
+                    BaseMedium="#FF526F9B"
+                    BaseMediumHigh="#FF20477A"
+                    BaseMediumLow="#FF395B8A"
+                    ChromeAltLow="#FF20477A"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF9CAACC"
+                    ChromeBlackMedium="#FF20477A"
+                    ChromeBlackMediumLow="#FF526F9B"
+                    ChromeDisabledHigh="#FF9CAACC"
+                    ChromeDisabledLow="#FF526F9B"
+                    ChromeGray="#FF395B8A"
+                    ChromeHigh="#FF9CAACC"
+                    ChromeLow="#FFD4E0F8"
+                    ChromeMedium="#FFC9D5EF"
+                    ChromeMediumLow="#FFD4E0F8"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFC9D5EF"
+                    ListMedium="#FF9CAACC" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF0954CF</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -114,11 +172,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF9CAACC</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFC9D5EF</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF9CAACC</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">4,4,4,4</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">5,5,5,5</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">0</Thickness>
@@ -143,22 +206,26 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">0,0,0,0</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">0,0,0,0</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">0</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF266AD7</Color>
                     <Color x:Key="SystemAccentColorLight2">#FF4380E0</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF6195E8</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF0748BE</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF053CAD</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF04319C</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFFFF8F9</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Middle Blue.xaml
+++ b/CustomThemesPackage/Middle Blue.xaml
@@ -1,7 +1,8 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
@@ -11,10 +12,10 @@
                     <Color x:Key="SolidBackgroundFillColorTertiary">#5885AF</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#C3E0E5</Color>
                     <Color x:Key="SolidBackgroundAcrylic">#C3E0E5</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -26,10 +27,10 @@
                     <Color x:Key="SolidBackgroundFillColorTertiary">#5885AF</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#274472</Color>
                     <Color x:Key="SolidBackgroundAcrylic">#274472</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/CustomThemesPackage/Midnight.xaml
+++ b/CustomThemesPackage/Midnight.xaml
@@ -1,12 +1,39 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCC4D11" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF2F7BAD" BaseMedium="#FF8DBFDF" BaseMediumHigh="#FFA5D0EC" BaseMediumLow="#FF5E9DC6" ChromeAltLow="#FFA5D0EC" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFA5D0EC" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF2F7BAD" ChromeDisabledLow="#FF8DBFDF" ChromeGray="#FF76AED3" ChromeHigh="#FF76AED3" ChromeLow="#FF093B73" ChromeMedium="#FF134B82" ChromeMediumLow="#FF266B9F" ChromeWhite="#FFFFFFFF" ListLow="#FF134B82" ListMedium="#FF2F7BAD" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCC4D11"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF2F7BAD"
+                    BaseMedium="#FF8DBFDF"
+                    BaseMediumHigh="#FFA5D0EC"
+                    BaseMediumLow="#FF5E9DC6"
+                    ChromeAltLow="#FFA5D0EC"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFA5D0EC"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF2F7BAD"
+                    ChromeDisabledLow="#FF8DBFDF"
+                    ChromeGray="#FF76AED3"
+                    ChromeHigh="#FF76AED3"
+                    ChromeLow="#FF093B73"
+                    ChromeMedium="#FF134B82"
+                    ChromeMediumLow="#FF266B9F"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF134B82"
+                    ListMedium="#FF2F7BAD" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCC4D11</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,11 +65,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF2F7BAD</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF134B82</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF2F7BAD</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -67,7 +99,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FFD4632D</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFDC7949</Color>
                     <Color x:Key="SystemAccentColorDark3">#FFE58E66</Color>
@@ -75,14 +107,14 @@
                     <Color x:Key="SystemAccentColorLight2">#FFA62F0A</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF932107</Color>
                     <Color x:Key="RegionColor">#03080F</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
 
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
                     <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#201F1E" />
                     <SolidColorBrush x:Key="SystemControlPageBackgroundMediumAltMediumBrush" Color="#99000000" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource RegionColor}" />
 
                     <Color x:Key="ControlStrokeColorDefault">#33000000</Color>
                     <Color x:Key="ControlStrokeColorSecondary">#73000000</Color>
@@ -92,8 +124,8 @@
                     <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="#0BFFFFFF" />
                     <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="#00FFFFFF" />
                     <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="#15FFFFFF" />
-                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource ControlStrokeColorDefault}" />
-                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource ControlStrokeColorSecondary}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{ThemeResource ControlStrokeColorSecondary}" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="#33000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="#73000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="#37000000" />
@@ -103,7 +135,33 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCC4D11" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FF7CBEE0" BaseMedium="#FF3282A8" BaseMediumHigh="#FF005A83" BaseMediumLow="#FF196E96" ChromeAltLow="#FF005A83" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF7CBEE0" ChromeBlackMedium="#FF005A83" ChromeBlackMediumLow="#FF3282A8" ChromeDisabledHigh="#FF7CBEE0" ChromeDisabledLow="#FF3282A8" ChromeGray="#FF196E96" ChromeHigh="#FF7CBEE0" ChromeLow="#FFC1E9FE" ChromeMedium="#FFB3E0F8" ChromeMediumLow="#FFC1E9FE" ChromeWhite="#FFFFFFFF" ListLow="#FFB3E0F8" ListMedium="#FF7CBEE0" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCC4D11"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FF7CBEE0"
+                    BaseMedium="#FF3282A8"
+                    BaseMediumHigh="#FF005A83"
+                    BaseMediumLow="#FF196E96"
+                    ChromeAltLow="#FF005A83"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF7CBEE0"
+                    ChromeBlackMedium="#FF005A83"
+                    ChromeBlackMediumLow="#FF3282A8"
+                    ChromeDisabledHigh="#FF7CBEE0"
+                    ChromeDisabledLow="#FF3282A8"
+                    ChromeGray="#FF196E96"
+                    ChromeHigh="#FF7CBEE0"
+                    ChromeLow="#FFC1E9FE"
+                    ChromeMedium="#FFB3E0F8"
+                    ChromeMediumLow="#FFC1E9FE"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFB3E0F8"
+                    ListMedium="#FF7CBEE0" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCC4D11</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -135,11 +193,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF7CBEE0</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFB3E0F8</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF7CBEE0</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -164,16 +227,20 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FFD4632D</Color>
                     <Color x:Key="SystemAccentColorLight2">#FFDC7949</Color>
                     <Color x:Key="SystemAccentColorLight3">#FFE58E66</Color>
                     <Color x:Key="SystemAccentColorDark1">#FFB93E0E</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFA62F0A</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF932107</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFCFEAFF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
 
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
@@ -184,10 +251,10 @@
                     <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#F9F9F9</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFFFF</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                     <Color x:Key="ControlStrokeColorDefault">#0F000000</Color>
                     <Color x:Key="ControlStrokeColorSecondary">#29000000</Color>
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#B3FFFFFF" />
@@ -196,8 +263,8 @@
                     <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="#4DF9F9F9" />
                     <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="#00FFFFFF" />
                     <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="#FFFFFF" />
-                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource ControlStrokeColorDefault}" />
-                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource ControlStrokeColorSecondary}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{ThemeResource ControlStrokeColorSecondary}" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="#0F000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="#29000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="#37000000" />
@@ -207,7 +274,33 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FFCC4D11" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FF7CBEE0" BaseMedium="#FF3282A8" BaseMediumHigh="#FF005A83" BaseMediumLow="#FF196E96" ChromeAltLow="#FF005A83" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FF7CBEE0" ChromeBlackMedium="#FF005A83" ChromeBlackMediumLow="#FF3282A8" ChromeDisabledHigh="#FF7CBEE0" ChromeDisabledLow="#FF3282A8" ChromeGray="#FF196E96" ChromeHigh="#FF7CBEE0" ChromeLow="#FFC1E9FE" ChromeMedium="#FFB3E0F8" ChromeMediumLow="#FFC1E9FE" ChromeWhite="#FFFFFFFF" ListLow="#FFB3E0F8" ListMedium="#FF7CBEE0" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FFCC4D11"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FF7CBEE0"
+                    BaseMedium="#FF3282A8"
+                    BaseMediumHigh="#FF005A83"
+                    BaseMediumLow="#FF196E96"
+                    ChromeAltLow="#FF005A83"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FF7CBEE0"
+                    ChromeBlackMedium="#FF005A83"
+                    ChromeBlackMediumLow="#FF3282A8"
+                    ChromeDisabledHigh="#FF7CBEE0"
+                    ChromeDisabledLow="#FF3282A8"
+                    ChromeGray="#FF196E96"
+                    ChromeHigh="#FF7CBEE0"
+                    ChromeLow="#FFC1E9FE"
+                    ChromeMedium="#FFB3E0F8"
+                    ChromeMediumLow="#FFC1E9FE"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFB3E0F8"
+                    ListMedium="#FF7CBEE0" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FFCC4D11</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -239,11 +332,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF7CBEE0</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFB3E0F8</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF7CBEE0</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -268,16 +366,20 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FFD4632D</Color>
                     <Color x:Key="SystemAccentColorLight2">#FFDC7949</Color>
                     <Color x:Key="SystemAccentColorLight3">#FFE58E66</Color>
                     <Color x:Key="SystemAccentColorDark1">#FFB93E0E</Color>
                     <Color x:Key="SystemAccentColorDark2">#FFA62F0A</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF932107</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{StaticResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFCFEAFF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
 
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
                     <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
@@ -288,10 +390,10 @@
                     <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#F9F9F9</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFFFF</Color>
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SolidBackgroundFillColorBase}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                     <Color x:Key="ControlStrokeColorDefault">#0F000000</Color>
                     <Color x:Key="ControlStrokeColorSecondary">#29000000</Color>
                     <SolidColorBrush x:Key="ControlFillColorDefaultBrush" Color="#B3FFFFFF" />
@@ -300,8 +402,8 @@
                     <SolidColorBrush x:Key="ControlFillColorDisabledBrush" Color="#4DF9F9F9" />
                     <SolidColorBrush x:Key="ControlFillColorTransparentBrush" Color="#00FFFFFF" />
                     <SolidColorBrush x:Key="ControlFillColorInputActiveBrush" Color="#FFFFFF" />
-                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{StaticResource ControlStrokeColorDefault}" />
-                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{StaticResource ControlStrokeColorSecondary}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="ControlStrokeColorSecondaryBrush" Color="{ThemeResource ControlStrokeColorSecondary}" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentDefaultBrush" Color="#0F000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentSecondaryBrush" Color="#29000000" />
                     <SolidColorBrush x:Key="ControlStrokeColorOnAccentTertiaryBrush" Color="#37000000" />
@@ -311,7 +413,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Nightshade.xaml
+++ b/CustomThemesPackage/Nightshade.xaml
@@ -1,12 +1,39 @@
-<!-- This file is licensed under the MIT License, and is made by DeveloperWOW64. (github.com/DeveloperWOW64) -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  This file is licensed under the MIT License, and is made by DeveloperWOW64. (github.com/DeveloperWOW64)  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF22CFA0" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF262626" BaseMedium="#FF949494" BaseMediumHigh="#FFAFAFAF" BaseMediumLow="#FF5D5D5D" ChromeAltLow="#FFAFAFAF" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFAFAFAF" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF262626" ChromeDisabledLow="#FF949494" ChromeGray="#FF787878" ChromeHigh="#FF787878" ChromeLow="#FF101010" ChromeMedium="#FF151515" ChromeMediumLow="#FF202020" ChromeWhite="#FFFFFFFF" ListLow="#FF151515" ListMedium="#FF262626" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF22CFA0"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF262626"
+                    BaseMedium="#FF949494"
+                    BaseMediumHigh="#FFAFAFAF"
+                    BaseMediumLow="#FF5D5D5D"
+                    ChromeAltLow="#FFAFAFAF"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFAFAFAF"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF262626"
+                    ChromeDisabledLow="#FF949494"
+                    ChromeGray="#FF787878"
+                    ChromeHigh="#FF787878"
+                    ChromeLow="#FF101010"
+                    ChromeMedium="#FF151515"
+                    ChromeMediumLow="#FF202020"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF151515"
+                    ListMedium="#FF262626" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF22CFA0</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,11 +65,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF262626</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF151515</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF262626</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -67,7 +99,7 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FF3BD6AC</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF53DCB8</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF6CE3C3</Color>
@@ -75,13 +107,39 @@
                     <Color x:Key="SystemAccentColorLight2">#FF14A477</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF0E8F62</Color>
                     <Color x:Key="RegionColor">#FF333333</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF022CFA" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FFCCCCCC" BaseMedium="#FF898989" BaseMediumHigh="#FF5D5D5D" BaseMediumLow="#FF737373" ChromeAltLow="#FF5D5D5D" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFCCCCCC" ChromeBlackMedium="#FF5D5D5D" ChromeBlackMediumLow="#FF898989" ChromeDisabledHigh="#FFCCCCCC" ChromeDisabledLow="#FF898989" ChromeGray="#FF737373" ChromeHigh="#FFCCCCCC" ChromeLow="#FFECECEC" ChromeMedium="#FFE6E6E6" ChromeMediumLow="#FFECECEC" ChromeWhite="#FFFFFFFF" ListLow="#FFE6E6E6" ListMedium="#FFCCCCCC" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF022CFA"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FFCCCCCC"
+                    BaseMedium="#FF898989"
+                    BaseMediumHigh="#FF5D5D5D"
+                    BaseMediumLow="#FF737373"
+                    ChromeAltLow="#FF5D5D5D"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFCCCCCC"
+                    ChromeBlackMedium="#FF5D5D5D"
+                    ChromeBlackMediumLow="#FF898989"
+                    ChromeDisabledHigh="#FFCCCCCC"
+                    ChromeDisabledLow="#FF898989"
+                    ChromeGray="#FF737373"
+                    ChromeHigh="#FFCCCCCC"
+                    ChromeLow="#FFECECEC"
+                    ChromeMedium="#FFE6E6E6"
+                    ChromeMediumLow="#FFECECEC"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFE6E6E6"
+                    ListMedium="#FFCCCCCC" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF022CFA</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -113,11 +171,16 @@
                     <Color x:Key="SystemChromeAltHighColor">#FFCCCCCC</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFE6E6E6</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FFCCCCCC</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system shape defaults -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system shape defaults  -->
                     <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
                     <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
-                    <!-- Override system borders -->
+                    <!--  Override system borders  -->
                     <Thickness x:Key="MenuBarItemBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="GridViewItemMultiselectBorderThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="CheckBoxBorderThemeThickness">1</Thickness>
@@ -142,22 +205,26 @@
                     <Thickness x:Key="GridViewItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <Thickness x:Key="ComboBoxItemRevealBorderThemeThickness">1,1,1,1</Thickness>
                     <x:Double x:Key="PersonPictureEllipseBadgeStrokeThickness">1</x:Double>
-                    <!-- Override system generated accent colors -->
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF2147FB</Color>
                     <Color x:Key="SystemAccentColorLight2">#FF4061FC</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF5E7CFD</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF0225E5</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF011DD0</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF0116BA</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFEBECFF</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/CustomThemesPackage/Not so Dark.xaml
+++ b/CustomThemesPackage/Not so Dark.xaml
@@ -1,12 +1,39 @@
-<!-- Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
-                    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)">
+<!--  Free Public License 1.0.0 Permission to use, copy, modify, and/or distribute this code for any purpose with or without fee is hereby granted.  -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:BelowWindows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF506C94" AltHigh="#FF000000" AltLow="#FF000000" AltMedium="#FF000000" AltMediumHigh="#FF000000" AltMediumLow="#FF000000" BaseHigh="#FFFFFFFF" BaseLow="#FF3C4B66" BaseMedium="#FF9AA5BC" BaseMediumHigh="#FFB1BCD2" BaseMediumLow="#FF6B7891" ChromeAltLow="#FFB1BCD2" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFB1BCD2" ChromeBlackMedium="#FF000000" ChromeBlackMediumLow="#FF000000" ChromeDisabledHigh="#FF3C4B66" ChromeDisabledLow="#FF9AA5BC" ChromeGray="#FF828FA7" ChromeHigh="#FF828FA7" ChromeLow="#FF0C2144" ChromeMedium="#FF182C4D" ChromeMediumLow="#FF30415E" ChromeWhite="#FFFFFFFF" ListLow="#FF182C4D" ListMedium="#FF3C4B66" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF506C94"
+                    AltHigh="#FF000000"
+                    AltLow="#FF000000"
+                    AltMedium="#FF000000"
+                    AltMediumHigh="#FF000000"
+                    AltMediumLow="#FF000000"
+                    BaseHigh="#FFFFFFFF"
+                    BaseLow="#FF3C4B66"
+                    BaseMedium="#FF9AA5BC"
+                    BaseMediumHigh="#FFB1BCD2"
+                    BaseMediumLow="#FF6B7891"
+                    ChromeAltLow="#FFB1BCD2"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFB1BCD2"
+                    ChromeBlackMedium="#FF000000"
+                    ChromeBlackMediumLow="#FF000000"
+                    ChromeDisabledHigh="#FF3C4B66"
+                    ChromeDisabledLow="#FF9AA5BC"
+                    ChromeGray="#FF828FA7"
+                    ChromeHigh="#FF828FA7"
+                    ChromeLow="#FF0C2144"
+                    ChromeMedium="#FF182C4D"
+                    ChromeMediumLow="#FF30415E"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FF182C4D"
+                    ListMedium="#FF3C4B66" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF506C94</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FF000000</BelowWindows10version1809:Color>
@@ -38,8 +65,13 @@
                     <Color x:Key="SystemChromeAltHighColor">#FF3C4B66</Color>
                     <Color x:Key="SystemRevealListLowColor">#FF182C4D</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FF3C4B66</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system generated accent colors -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorDark1">#FF647FA4</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF7992B4</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF8DA4C3</Color>
@@ -47,7 +79,7 @@
                     <Color x:Key="SystemAccentColorLight2">#FF304F7B</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF20416F</Color>
                     <Color x:Key="RegionColor">#FF2D384C</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                     <Color x:Key="BaseColor">#FF3C4B66</Color>
                     <Color x:Key="BasePalette000Color">#FFB1BCD2</Color>
                     <Color x:Key="BasePalette100Color">#FF9AA5BC</Color>
@@ -72,46 +104,72 @@
                     <Color x:Key="PrimaryPalette800Color">#FF20416F</Color>
                     <Color x:Key="PrimaryPalette900Color">#FF103262</Color>
                     <Color x:Key="PrimaryPalette1000Color">#FF002456</Color>
-                    <SolidColorBrush x:Key="BaseBrush" Color="{StaticResource BaseColor}" />
-                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{StaticResource BasePalette300Color}" />
-                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{StaticResource BasePalette400Color}" />
-                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{StaticResource BasePalette500Color}" />
-                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{StaticResource BasePalette600Color}" />
-                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{StaticResource BasePalette700Color}" />
-                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{StaticResource BasePalette800Color}" />
-                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{StaticResource BasePalette900Color}" />
-                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{StaticResource BasePalette1000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{StaticResource PrimaryPalette000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{StaticResource PrimaryPalette100Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{StaticResource PrimaryPalette200Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{StaticResource PrimaryPalette300Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{StaticResource PrimaryPalette400Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{StaticResource PrimaryPalette500Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{StaticResource PrimaryPalette600Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{StaticResource PrimaryPalette700Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{StaticResource PrimaryPalette800Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{StaticResource PrimaryPalette900Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{StaticResource PrimaryPalette1000Color}" />
-                    <!-- Files-specific overrides -->
+                    <SolidColorBrush x:Key="BaseBrush" Color="{ThemeResource BaseColor}" />
+                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{ThemeResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{ThemeResource BasePalette400Color}" />
+                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{ThemeResource BasePalette500Color}" />
+                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{ThemeResource BasePalette600Color}" />
+                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{ThemeResource BasePalette700Color}" />
+                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{ThemeResource BasePalette800Color}" />
+                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{ThemeResource BasePalette900Color}" />
+                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{ThemeResource BasePalette1000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{ThemeResource PrimaryPalette000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{ThemeResource PrimaryPalette100Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{ThemeResource PrimaryPalette200Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{ThemeResource PrimaryPalette300Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{ThemeResource PrimaryPalette400Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{ThemeResource PrimaryPalette500Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{ThemeResource PrimaryPalette600Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{ThemeResource PrimaryPalette700Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{ThemeResource PrimaryPalette800Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{ThemeResource PrimaryPalette900Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{ThemeResource PrimaryPalette1000Color}" />
+                    <!--  Files-specific overrides  -->
                     <Color x:Key="SolidBackgroundFillColorBase">#FF2D384C</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#FF182C4D</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#FF0C2144</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FF00173C</Color>
                     <Color x:Key="SolidBackgroundAcrylic">#FF00173C</Color>
-                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource RegionColor}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource RegionColor}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource RegionColor}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource BasePalette300Color}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <ResourceDictionary.MergedDictionaries>
-                <Windows10version1809:ColorPaletteResources Accent="#FF2B3A4F" AltHigh="#FFFFFFFF" AltLow="#FFFFFFFF" AltMedium="#FFFFFFFF" AltMediumHigh="#FFFFFFFF" AltMediumLow="#FFFFFFFF" BaseHigh="#FF000000" BaseLow="#FFF9F9F9" BaseMedium="#FFADADAD" BaseMediumHigh="#FF7A7A7A" BaseMediumLow="#FF939393" ChromeAltLow="#FF7A7A7A" ChromeBlackHigh="#FF000000" ChromeBlackLow="#FFF9F9F9" ChromeBlackMedium="#FF7A7A7A" ChromeBlackMediumLow="#FFADADAD" ChromeDisabledHigh="#FFF9F9F9" ChromeDisabledLow="#FFADADAD" ChromeGray="#FF939393" ChromeHigh="#FFF9F9F9" ChromeLow="#FFFDFDFD" ChromeMedium="#FFFCFCFC" ChromeMediumLow="#FFFDFDFD" ChromeWhite="#FFFFFFFF" ListLow="#FFFCFCFC" ListMedium="#FFF9F9F9" />
+                <Windows10version1809:ColorPaletteResources
+                    Accent="#FF2B3A4F"
+                    AltHigh="#FFFFFFFF"
+                    AltLow="#FFFFFFFF"
+                    AltMedium="#FFFFFFFF"
+                    AltMediumHigh="#FFFFFFFF"
+                    AltMediumLow="#FFFFFFFF"
+                    BaseHigh="#FF000000"
+                    BaseLow="#FFF9F9F9"
+                    BaseMedium="#FFADADAD"
+                    BaseMediumHigh="#FF7A7A7A"
+                    BaseMediumLow="#FF939393"
+                    ChromeAltLow="#FF7A7A7A"
+                    ChromeBlackHigh="#FF000000"
+                    ChromeBlackLow="#FFF9F9F9"
+                    ChromeBlackMedium="#FF7A7A7A"
+                    ChromeBlackMediumLow="#FFADADAD"
+                    ChromeDisabledHigh="#FFF9F9F9"
+                    ChromeDisabledLow="#FFADADAD"
+                    ChromeGray="#FF939393"
+                    ChromeHigh="#FFF9F9F9"
+                    ChromeLow="#FFFDFDFD"
+                    ChromeMedium="#FFFCFCFC"
+                    ChromeMediumLow="#FFFDFDFD"
+                    ChromeWhite="#FFFFFFFF"
+                    ListLow="#FFFCFCFC"
+                    ListMedium="#FFF9F9F9" />
                 <ResourceDictionary>
                     <BelowWindows10version1809:Color x:Key="SystemAccentColor">#FF2B3A4F</BelowWindows10version1809:Color>
                     <BelowWindows10version1809:Color x:Key="SystemAltHighColor">#FFFFFFFF</BelowWindows10version1809:Color>
@@ -143,17 +201,26 @@
                     <Color x:Key="SystemChromeAltHighColor">#FFF9F9F9</Color>
                     <Color x:Key="SystemRevealListLowColor">#FFFCFCFC</Color>
                     <Color x:Key="SystemRevealListMediumColor">#FFF9F9F9</Color>
-                    <AcrylicBrush x:Key="SystemControlAcrylicWindowBrush" BackgroundSource="HostBackdrop" TintColor="{ThemeResource SystemChromeAltHighColor}" TintOpacity="0.8" FallbackColor="{ThemeResource SystemChromeMediumColor}" />
-                    <!-- Override system generated accent colors -->
+                    <AcrylicBrush
+                        x:Key="SystemControlAcrylicWindowBrush"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{ThemeResource SystemChromeMediumColor}"
+                        TintColor="{ThemeResource SystemChromeAltHighColor}"
+                        TintOpacity="0.8" />
+                    <!--  Override system generated accent colors  -->
                     <Color x:Key="SystemAccentColorLight1">#FF445367</Color>
                     <Color x:Key="SystemAccentColorLight2">#FF5E6C80</Color>
                     <Color x:Key="SystemAccentColorLight3">#FF778598</Color>
                     <Color x:Key="SystemAccentColorDark1">#FF223249</Color>
                     <Color x:Key="SystemAccentColorDark2">#FF1A2A43</Color>
                     <Color x:Key="SystemAccentColorDark3">#FF11233D</Color>
-                    <RevealBackgroundBrush x:Key="SystemControlHighlightListLowRevealBackgroundBrush" TargetTheme="Light" Color="{ThemeResource SystemRevealListMediumColor}" FallbackColor="{ StaticResource SystemListMediumColor}" />
+                    <RevealBackgroundBrush
+                        x:Key="SystemControlHighlightListLowRevealBackgroundBrush"
+                        FallbackColor="{ThemeResource SystemListMediumColor}"
+                        TargetTheme="Light"
+                        Color="{ThemeResource SystemRevealListMediumColor}" />
                     <Color x:Key="RegionColor">#FFEBE9EA</Color>
-                    <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+                    <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
                     <Color x:Key="BaseColor">#FFF9F9F9</Color>
                     <Color x:Key="BasePalette000Color">#FFFDFDFD</Color>
                     <Color x:Key="BasePalette100Color">#FFFCFCFC</Color>
@@ -178,46 +245,46 @@
                     <Color x:Key="PrimaryPalette800Color">#FF11233D</Color>
                     <Color x:Key="PrimaryPalette900Color">#FF091B37</Color>
                     <Color x:Key="PrimaryPalette1000Color">#FF001331</Color>
-                    <SolidColorBrush x:Key="BaseBrush" Color="{StaticResource BaseColor}" />
-                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{StaticResource BasePalette300Color}" />
-                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{StaticResource BasePalette400Color}" />
-                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{StaticResource BasePalette500Color}" />
-                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{StaticResource BasePalette600Color}" />
-                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{StaticResource BasePalette700Color}" />
-                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{StaticResource BasePalette800Color}" />
-                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{StaticResource BasePalette900Color}" />
-                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{StaticResource BasePalette1000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{StaticResource PrimaryPalette000Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{StaticResource PrimaryPalette100Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{StaticResource PrimaryPalette200Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{StaticResource PrimaryPalette300Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{StaticResource PrimaryPalette400Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{StaticResource PrimaryPalette500Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{StaticResource PrimaryPalette600Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{StaticResource PrimaryPalette700Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{StaticResource PrimaryPalette800Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{StaticResource PrimaryPalette900Color}" />
-                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{StaticResource PrimaryPalette1000Color}" />
-                    <!-- Files-specific overrides -->
+                    <SolidColorBrush x:Key="BaseBrush" Color="{ThemeResource BaseColor}" />
+                    <SolidColorBrush x:Key="BasePalette000Brush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="BasePalette100Brush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="BasePalette200Brush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="BasePalette300Brush" Color="{ThemeResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="BasePalette400Brush" Color="{ThemeResource BasePalette400Color}" />
+                    <SolidColorBrush x:Key="BasePalette500Brush" Color="{ThemeResource BasePalette500Color}" />
+                    <SolidColorBrush x:Key="BasePalette600Brush" Color="{ThemeResource BasePalette600Color}" />
+                    <SolidColorBrush x:Key="BasePalette700Brush" Color="{ThemeResource BasePalette700Color}" />
+                    <SolidColorBrush x:Key="BasePalette800Brush" Color="{ThemeResource BasePalette800Color}" />
+                    <SolidColorBrush x:Key="BasePalette900Brush" Color="{ThemeResource BasePalette900Color}" />
+                    <SolidColorBrush x:Key="BasePalette1000Brush" Color="{ThemeResource BasePalette1000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette000Brush" Color="{ThemeResource PrimaryPalette000Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette100Brush" Color="{ThemeResource PrimaryPalette100Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette200Brush" Color="{ThemeResource PrimaryPalette200Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette300Brush" Color="{ThemeResource PrimaryPalette300Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette400Brush" Color="{ThemeResource PrimaryPalette400Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette500Brush" Color="{ThemeResource PrimaryPalette500Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette600Brush" Color="{ThemeResource PrimaryPalette600Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette700Brush" Color="{ThemeResource PrimaryPalette700Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette800Brush" Color="{ThemeResource PrimaryPalette800Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette900Brush" Color="{ThemeResource PrimaryPalette900Color}" />
+                    <SolidColorBrush x:Key="PrimaryPalette1000Brush" Color="{ThemeResource PrimaryPalette1000Color}" />
+                    <!--  Files-specific overrides  -->
                     <Color x:Key="SolidBackgroundFillColorBase">#FFEBE9EA</Color>
                     <Color x:Key="SolidBackgroundFillColorSecondary">#FFFCFCFC</Color>
                     <Color x:Key="SolidBackgroundFillColorTertiary">#FFFBFBFB</Color>
                     <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFBFBFB</Color>
                     <Color x:Key="SolidBackgroundAcrylic">#FFFBFBFB</Color>
-                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource BasePalette000Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource BasePalette100Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource BasePalette200Color}" />
-                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource BasePalette300Color}" />
+                    <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource BasePalette000Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource BasePalette100Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource BasePalette200Color}" />
+                    <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource BasePalette300Color}" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RegionColor" ResourceKey="SystemColorWindowColor" />
-            <SolidColorBrush x:Key="RegionBrush" Color="{StaticResource RegionColor}" />
+            <SolidColorBrush x:Key="RegionBrush" Color="{ThemeResource RegionColor}" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
This fixes issues where brushes would not update after switching between light/dark mode. 
This also formats themes with the xaml formatter. 

I tested each theme in both light and dark mode, all seems good. 