### PR TITLE
Black Pixel V8: Re-add light accent color overrides

### DIFF
--- a/CustomThemesPackage/Black Pixel.xaml
+++ b/CustomThemesPackage/Black Pixel.xaml
@@ -23,6 +23,9 @@
             <Color x:Key="SystemAccentColorDark1">#66FFFFFF</Color>
             <Color x:Key="SystemAccentColorDark2">#1A73E8</Color>
             <Color x:Key="SystemAccentColorDark3">#1A73E8</Color>    
+            <Color x:Key="SystemAccentColorLight1">#1A73E8</Color>
+            <Color x:Key="SystemAccentColorLight2">#1A73E8</Color>
+            <Color x:Key="SystemAccentColorLight3">#1A73E8</Color>
             <!-- Corners -->
             <CornerRadius x:Key="ControlCornerRadius">8</CornerRadius>
             <CornerRadius x:Key="NavToolbarCornerRadius">16</CornerRadius>


### PR DESCRIPTION
A temporary fix for WinUI/Win11 accent color brushes/theming issues.